### PR TITLE
add noResults text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
+## 0.5.0
+* New translation object string `noResults` is now displayed when there's no list items to show
 
 ## 0.4.0
 * Added more possibilities to customize list functionality

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | itemHeight                | number                  | 40                                           | Height of the item in the list in pixels    |
 | columnHeaderHeight        | number                  | 40                                           | Height of the column header in pixels       |
 | idKey                     | string                  | 'id'                                         | ID key of item data                         |
-| translations              | array of objects        | { search: 'Search', selectAll: 'All', showOnlySelected: 'Show only selected' } | Translations |
+| translations              | object                  | { search: 'Search', selectAll: 'All', showOnlySelected: 'Show only selected', noResults: 'There are no items to show in this list.' } | Translations |
 | customTheme               | object                  | [themeDefaults](src/theme.js)                | Override theme                              |
 | isSearchable              | boolean                 | false                                        | Is list searchable                          |
 | isSelectColumnVisible     | boolean                 | false                                        | Is select column visible                    |

--- a/src/list.component.jsx
+++ b/src/list.component.jsx
@@ -13,6 +13,11 @@ const ListContainer = styled.div`
   width: ${props => (props.width === 'auto' ? '100%' : `${props.width}px`)};
 `;
 
+const NoResultsText = styled.p`
+  text-align: center;
+  margin-top: 1rem;
+`;
+
 export default
 @withTheme
 class List extends React.PureComponent {
@@ -44,6 +49,7 @@ class List extends React.PureComponent {
       search: PropTypes.string,
       selectAll: PropTypes.string,
       showOnlySelected: PropTypes.string,
+      noResults: PropTypes.string,
     }),
     customTheme: themeShape, // theme override
     reactInfiniteProps: PropTypes.shape({}),
@@ -81,6 +87,7 @@ class List extends React.PureComponent {
       search: 'Search',
       selectAll: 'All',
       showOnlySelected: 'Show only selected',
+      noResults: 'There are no items to show in this list.',
     },
     customTheme: null,
     reactInfiniteProps: {},
@@ -291,6 +298,7 @@ class List extends React.PureComponent {
           reactInfiniteProps={reactInfiniteProps}
         >
           {filteredItems.map(this.renderRow)}
+          {!filteredItems.length && <NoResultsText>{translations.noResults}</NoResultsText>}
         </ResponsiveListContainer>
       </ListContainer>
     );


### PR DESCRIPTION
* New translation object string `noResults` is now displayed when there's no list items to show
