### PR TITLE
Fix SortableItem rendering behind e.g. Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
+## <next>
+* Add `dragItemZindex` prop for raising the SortableItems z-index on top of e.g. bootstrap Modal.
+* Added new example to show `dragItemZindex` in action.
 
 ## 1.0.0
 * Sorting with drag'n'drop

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | width                     | number or 'auto'        | 'auto'                                       | Width of the list in pixels                 |
 | itemHeight                | number                  | 40                                           | Height of the item in the list in pixels    |
 | columnHeaderHeight        | number                  | 40                                           | Height of the column header in pixels       |
+| dragItemZindex            | number                  | 1060                                         | draggable items z-index                     |
 | idKey                     | string                  | 'id'                                         | ID key of item data                         |
 | translations              | object                  | { search: 'Search', selectAll: 'All', showOnlySelected: 'Show only selected', noResults: 'There are no items to show in this list.' } | Translations |
 | customTheme               | object                  | [themeDefaults](src/theme.js)                | Override theme                              |

--- a/src/list.component.jsx
+++ b/src/list.component.jsx
@@ -44,6 +44,7 @@ class List extends React.PureComponent {
     ]),
     itemHeight: PropTypes.number,
     columnHeaderHeight: PropTypes.number,
+    dragItemZindex: PropTypes.number,
     idKey: PropTypes.string, // key of id in list data
     translations: PropTypes.shape({
       search: PropTypes.string,
@@ -84,6 +85,7 @@ class List extends React.PureComponent {
     width: 'auto',
     itemHeight: 40,
     columnHeaderHeight: 40,
+    dragItemZindex: 1060,
     idKey: 'id',
     translations: {
       search: 'Search',
@@ -243,6 +245,7 @@ class List extends React.PureComponent {
       width,
       itemHeight,
       columnHeaderHeight,
+      dragItemZindex,
       isColumnHeaderVisible,
       isSearchable,
       isSelectColumnVisible,
@@ -306,6 +309,7 @@ class List extends React.PureComponent {
           height={height}
           itemHeight={itemHeight}
           columnHeaderHeight={columnHeaderHeight}
+          dragItemZindex={dragItemZindex}
           isHeaderVisible={isHeaderVisible}
           isColumnHeaderVisible={isColumnHeaderVisible}
           isSortable={isSortable}

--- a/src/responsive-list-container.component.jsx
+++ b/src/responsive-list-container.component.jsx
@@ -22,11 +22,16 @@ const ItemContainer = styled.div`
   overflow: hidden;
   padding: 0;
   margin: 0;
+  z-index: ${props => props.dragItemZindex};
 `;
 
-const Item = ({ value }) => <ItemContainer>{value}</ItemContainer>;
+const Item = ({
+  value,
+  dragItemZindex,
+}) => <ItemContainer dragItemZindex={dragItemZindex}>{value}</ItemContainer>;
 Item.propTypes = {
   value: PropTypes.node.isRequired,
+  dragItemZindex: PropTypes.number.isRequired,
 };
 
 const InfiniteList = ({ items, reactInfiniteProps }) => (
@@ -46,13 +51,14 @@ InfiniteList.propTypes = {
 };
 
 const SortableItem = sortableElement(Item);
-const SortableInfiniteList = sortableContainer(({ items, reactInfiniteProps }) => (
+const SortableInfiniteList = sortableContainer(({ items, reactInfiniteProps, dragItemZindex }) => (
   <Infinite {...reactInfiniteProps}>
     {items.map((value, index) => (
       <SortableItem
         key={`item-${index}`} // eslint-disable-line
         index={index}
         value={value}
+        dragItemZindex={dragItemZindex}
       />
     ))}
   </Infinite>
@@ -60,6 +66,7 @@ const SortableInfiniteList = sortableContainer(({ items, reactInfiniteProps }) =
 SortableInfiniteList.propTypes = {
   items: PropTypes.array.isRequired, // eslint-disable-line
   reactInfiniteProps: PropTypes.shape({}).isRequired,
+  dragItemZindex: PropTypes.number.isRequired,
 };
 
 export default class ResponsiveListContainer extends React.PureComponent {
@@ -72,6 +79,7 @@ export default class ResponsiveListContainer extends React.PureComponent {
     ]).isRequired,
     itemHeight: PropTypes.number.isRequired,
     columnHeaderHeight: PropTypes.number.isRequired,
+    dragItemZindex: PropTypes.number.isRequired,
     isHeaderVisible: PropTypes.bool.isRequired,
     isColumnHeaderVisible: PropTypes.bool.isRequired,
     isSortable: PropTypes.bool.isRequired,
@@ -137,6 +145,7 @@ export default class ResponsiveListContainer extends React.PureComponent {
       id,
       itemHeight,
       columnHeaderHeight,
+      dragItemZindex,
       isHeaderVisible,
       isColumnHeaderVisible,
       isSortable,
@@ -155,6 +164,7 @@ export default class ResponsiveListContainer extends React.PureComponent {
       items: React.Children.toArray(children),
       isSortable,
       onSortEnd,
+      dragItemZindex,
     };
     let headerHeight = isColumnHeaderVisible ? columnHeaderHeight : 0;
     if (isHeaderVisible) headerHeight += 40;

--- a/src_docs/components/list-in-modal.component.jsx
+++ b/src_docs/components/list-in-modal.component.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button } from 'react-bootstrap';
+import SimpleList from './simple-list.component';
+
+export default class ListModal extends React.PureComponent {
+  static propTypes = {
+    toggleModal: PropTypes.func.isRequired,
+  };
+
+  closeModal = () => this.props.toggleModal(false); // eslint-disable-line
+
+  render() {
+    return (
+      <Modal
+        bsSize="large"
+        dialogClassName="simpleModal"
+        aria-labelledby="simpleModal"
+        onHide={this.handleCancelClick}
+        show
+      >
+        <Modal.Header>
+          <Modal.Title>List in Modal</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <SimpleList {...this.props} />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button id="close" onClick={this.closeModal}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}

--- a/src_docs/containers/example-list-modal.component.jsx
+++ b/src_docs/containers/example-list-modal.component.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button } from 'react-bootstrap';
+import ListModal from '../components/list-in-modal.component';
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+export default class ListInModalContainer extends React.PureComponent {
+  state = {
+    modalVisible: false,
+  };
+
+  toggleModal = (visible = false) => { this.setState({ modalVisible: visible }); }
+
+  handleButtonClick = () => this.toggleModal(true);
+
+  renderModal = () => this.state.modalVisible && ( // eslint-disable-line
+    <ListModal {...this.props} toggleModal={this.toggleModal} />
+  );
+
+  render() {
+    return (
+      <Container>
+        <span>
+          Open/Close Modal with following button.
+          You can determine needed dragItem z-index with:
+          <code> dragItemZindex: 1060; </code>
+          which defaults to 1060 that should be enough for most cases.
+        </span>
+        <br />
+        <br />
+        <Button id="toggleModal" onClick={this.handleButtonClick}>
+          Toggle
+        </Button>
+        { this.renderModal() }
+      </Container>
+    );
+  }
+}

--- a/src_docs/containers/example.container.jsx
+++ b/src_docs/containers/example.container.jsx
@@ -14,6 +14,7 @@ import packageConfig from '../../package.json';
 import SimpleList from '../components/simple-list.component';
 import CustomRenderList from '../components/custom-render-list.component';
 import GroupList from '../components/group-list.component';
+import ListInModalContainer from './example-list-modal.component';
 
 const packageDescription = packageConfig.description;
 const packageName = packageConfig.name.replace('@opuscapita/', '');
@@ -37,6 +38,7 @@ export default class ExampleContainer extends React.PureComponent {
     isSelectAllVisible: false,
     isShowOnlySelectedVisible: false,
     isSortable: true,
+    dragItemZindex: 1060,
   }
 
   changeNumberProp = prop => (e) => {
@@ -102,6 +104,8 @@ export default class ExampleContainer extends React.PureComponent {
               <br />
               <Link to="/groups" href="/groups">Groups</Link>
               <br />
+              <Link to="/modal" href="/modal">List in BS Modal</Link>
+              <br />
             </Panel>
             <Panel style={{ padding: '20px' }}>
               {this.renderCheckbox('isIndexColumnVisible')}
@@ -112,6 +116,7 @@ export default class ExampleContainer extends React.PureComponent {
               {this.renderCheckbox('isSelectAllVisible')}
               {this.renderCheckbox('isShowOnlySelectedVisible')}
               {this.renderCheckbox('isSortable')}
+              {this.renderNumberInput('dragItemZindex')}
               {this.renderNumberInput('itemHeight')}
               {this.renderNumberInput('columnHeaderHeight')}
             </Panel>
@@ -127,6 +132,7 @@ export default class ExampleContainer extends React.PureComponent {
                     <Route path="/fixed-height" render={() => <SimpleList useColumnData key="4" height={400} {...this.state} />} />
                     <Route path="/fixed-size" render={() => <SimpleList key="5" height={400} width={400} {...this.state} />} />
                     <Route path="/groups" render={() => <GroupList key="6" {...this.state} />} />
+                    <Route path="/modal" render={() => <ListInModalContainer key="7" {...this.state} />} />
                   </Switch>
                 </ListContainer>
               </ThemeProvider>


### PR DESCRIPTION
Raised sortableItem components z-index to render Items on top of the Modal. Added example to see functionality before and after the fix