### PR TITLE
Remove arrayMove from demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## next
+* Remove `arrayMove` from the demos (incompatible with IE11)
 
 ## 1.2.1 
 * Upgrade packages

--- a/src_docs/components/custom-render-list.component.jsx
+++ b/src_docs/components/custom-render-list.component.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FaTrashAlt } from 'react-icons/fa';
-import arrayMove from 'array-move';
 import { Primitive } from '@opuscapita/oc-cm-common-layouts';
 import { FloatingSelectPortal } from '@opuscapita/react-floating-select';
 import List from '../../src/index';
 import { getNewColumnItem } from '../constants/data';
 import getCountryOptions from '../constants/countries';
+import { arrayMove } from './demo-utils';
 
 const Select = styled(FloatingSelectPortal)`
   width: 100%;

--- a/src_docs/components/demo-utils.js
+++ b/src_docs/components/demo-utils.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+export const arrayMove = (items, oldIndex, newIndex) => {
+  const newArray = items.slice();
+  const element = newArray[oldIndex];
+  newArray.splice(oldIndex, 1);
+  newArray.splice(newIndex, 0, element);
+  return newArray;
+};
+/* eslint-enable import/prefer-default-export */

--- a/src_docs/components/group-list.component.jsx
+++ b/src_docs/components/group-list.component.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import arrayMove from 'array-move';
 import Checkbox from '@opuscapita/react-checkbox';
 import List from '../../src/index';
 import { getGroupData } from '../constants/data';
+import { arrayMove } from './demo-utils';
 
 const ItemTextContainer = styled.span`
   text-overflow: ellipsis;

--- a/src_docs/components/simple-list.component.jsx
+++ b/src_docs/components/simple-list.component.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import arrayMove from 'array-move';
+import { arrayMove } from './demo-utils';
 import List from '../../src/index';
 import { getSimpleData, getColumnData } from '../constants/data';
 


### PR DESCRIPTION
Removed `arrayMove` package from demos because of an IE11 incompatibility. Replaced it with a custom made array sorter.