### PR TITLE
Add callback for "Show only selected" checkbox change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## next
+
+## 1.2.2
+* Add callback for "Show only selected" checkbox change
 * Remove `arrayMove` from the demos (incompatible with IE11)
 
 ## 1.2.1 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## next
 
-## 1.2.2
+## 1.3.0
 * Add callback for "Show only selected" checkbox change
 * Remove `arrayMove` from the demos (incompatible with IE11)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | isIndexColumnVisible      | boolean                 | false                                        | Is index column visible                     |
 | isItemBorderVisible       | boolean                 | true                                         | Is border visible between items             |
 | isSortable                | boolean                 | false                                        | Enable drag'n'drop sorting                  |
+| isShowOnlySelectedPassed  | boolean                 | false                                        | Is show only selected checkbox initial state passed |
 | onSelectedChange          | function                | (selectedIds: array)                         | Callback for selected items change          |
+| onShowOnlySelectedChange  | function                | (showOnlySelected: bool)                     | Callback for Show only selected change      |
 | onRowClick                | function                | (item: object, rowIndex: number)             | Callback for row click                      |
 | onRowDoubleClick          | function                | (item: object, rowIndex: number)             | Callback for row double click               |
 | onRowContextMenu          | function                | (item: object, rowIndex: number)             | Callback for row context menu (right click) |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | isIndexColumnVisible      | boolean                 | false                                        | Is index column visible                     |
 | isItemBorderVisible       | boolean                 | true                                         | Is border visible between items             |
 | isSortable                | boolean                 | false                                        | Enable drag'n'drop sorting                  |
-| isShowOnlySelectedPassed  | boolean                 | false                                        | Is show only selected checkbox initial state passed |
+| showOnlySelectedInitialValue | boolean              | false                                        | Show only selected checkbox initial state   |
 | onSelectedChange          | function                | (selectedIds: array)                         | Callback for selected items change          |
 | onShowOnlySelectedChange  | function                | (showOnlySelected: bool)                     | Callback for Show only selected change      |
 | onRowClick                | function                | (item: object, rowIndex: number)             | Callback for row click                      |

--- a/src/list.component.jsx
+++ b/src/list.component.jsx
@@ -168,7 +168,7 @@ class List extends React.PureComponent {
   handleShowOnlySelectedChange = () => {
     const { showOnlySelected } = this.state;
     const { onShowOnlySelectedChange } = this.props;
-    this.setState({ showOnlySelected: !showOnlySelected });
+    this.setState(prevState => ({ showOnlySelected: !prevState.showOnlySelected }));
     if (onShowOnlySelectedChange) {
       onShowOnlySelectedChange(!showOnlySelected);
     }

--- a/src/list.component.jsx
+++ b/src/list.component.jsx
@@ -69,9 +69,11 @@ class List extends React.PureComponent {
     isItemBorderVisible: PropTypes.bool,
     isAllSelected: PropTypes.bool,
     isSortable: PropTypes.bool,
+    isShowOnlySelectedPassed: PropTypes.bool,
 
     // actions
     onSelectedChange: PropTypes.func,
+    onShowOnlySelectedChange: PropTypes.func,
     onRowClick: PropTypes.func,
     onRowDoubleClick: PropTypes.func,
     onRowContextMenu: PropTypes.func,
@@ -109,7 +111,9 @@ class List extends React.PureComponent {
     isItemBorderVisible: true,
     isAllSelected: null,
     isSortable: false,
+    isShowOnlySelectedPassed: false,
     onSelectedChange: () => {},
+    onShowOnlySelectedChange: () => {},
     onRowClick: () => {},
     onRowDoubleClick: () => {},
     onRowContextMenu: () => {},
@@ -123,7 +127,7 @@ class List extends React.PureComponent {
     super(props);
     this.state = {
       searchKeyword: '',
-      showOnlySelected: false,
+      showOnlySelected: props.isShowOnlySelectedPassed,
     };
   }
 
@@ -163,7 +167,11 @@ class List extends React.PureComponent {
 
   handleShowOnlySelectedChange = () => {
     const { showOnlySelected } = this.state;
+    const { onShowOnlySelectedChange } = this.props;
     this.setState({ showOnlySelected: !showOnlySelected });
+    if (onShowOnlySelectedChange) {
+      onShowOnlySelectedChange(!showOnlySelected);
+    }
   };
 
   filter = () => {

--- a/src/list.component.jsx
+++ b/src/list.component.jsx
@@ -166,12 +166,13 @@ class List extends React.PureComponent {
   };
 
   handleShowOnlySelectedChange = () => {
-    const { showOnlySelected } = this.state;
     const { onShowOnlySelectedChange } = this.props;
-    this.setState(prevState => ({ showOnlySelected: !prevState.showOnlySelected }));
-    if (onShowOnlySelectedChange) {
-      onShowOnlySelectedChange(!showOnlySelected);
-    }
+    this.setState((prevState) => {
+      if (onShowOnlySelectedChange) {
+        onShowOnlySelectedChange(!prevState.showOnlySelected);
+      }
+      return ({ showOnlySelected: !prevState.showOnlySelected });
+    });
   };
 
   filter = () => {

--- a/src/list.component.jsx
+++ b/src/list.component.jsx
@@ -69,7 +69,7 @@ class List extends React.PureComponent {
     isItemBorderVisible: PropTypes.bool,
     isAllSelected: PropTypes.bool,
     isSortable: PropTypes.bool,
-    isShowOnlySelectedPassed: PropTypes.bool,
+    showOnlySelectedInitialValue: PropTypes.bool,
 
     // actions
     onSelectedChange: PropTypes.func,
@@ -111,7 +111,7 @@ class List extends React.PureComponent {
     isItemBorderVisible: true,
     isAllSelected: null,
     isSortable: false,
-    isShowOnlySelectedPassed: false,
+    showOnlySelectedInitialValue: false,
     onSelectedChange: () => {},
     onShowOnlySelectedChange: () => {},
     onRowClick: () => {},
@@ -127,7 +127,7 @@ class List extends React.PureComponent {
     super(props);
     this.state = {
       searchKeyword: '',
-      showOnlySelected: props.isShowOnlySelectedPassed,
+      showOnlySelected: props.showOnlySelectedInitialValue,
     };
   }
 


### PR DESCRIPTION
Add callback for "Show only selected" checkbox change and initial state if needed.
It can be applied when the component is used in several steps of one wizard. When switching between steps (tabs) the state for 'Show only selected' checkbox is not currently reachable